### PR TITLE
Silence false-positive warning when createInertiaApp is referenced but not called

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -41,12 +41,10 @@ export default function caseShift(options: CaseShiftPluginOptions = {}): Plugin 
         return transformCSR(code, imports, setup, inertiaCall, appId, optsArg)
       }
 
-      console.warn(
-        '[inertia-caseshift] Found createInertiaApp but could not locate the call site to transform. ' +
-        'The plugin expects a top-level createInertiaApp({ ... }) call with an object literal argument. ' +
-        'If you are using a non-standard setup, use setupCaseShift(http) and transformInitialPage() manually.',
-      )
-
+      // The substring check is a coarse pre-filter. Files that mention
+      // `createInertiaApp` without calling it at the top level — declarations,
+      // re-exports, library bundles like `@inertiajs/react/dist/index.js` —
+      // reach here normally. Treat that as "nothing to transform", not an error.
       return null
     },
   }

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { parse } from 'acorn'
 import caseShift from '../src/vite'
 
@@ -24,6 +24,22 @@ describe('caseShift vite plugin', () => {
   it('skips files that already import inertia-caseshift', () => {
     const code = `import { setupCaseShift } from 'inertia-caseshift'\ncreateInertiaApp({ resolve: fn })`
     expect(transform(code)).toBeNull()
+  })
+
+  it('silently returns null when createInertiaApp is referenced but not called at top level', () => {
+    // e.g. @inertiajs/react/dist/index.js, which declares and re-exports
+    // createInertiaApp but never calls it.
+    const code = [
+      `async function createInertiaApp(options) { return options }`,
+      `export { createInertiaApp }`,
+    ].join('\n')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      expect(transform(code)).toBeNull()
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   describe('CSR transform', () => {


### PR DESCRIPTION
## Summary

The Vite plugin's `transform` hook uses `code.includes("createInertiaApp")` as a coarse pre-filter, then parses and looks for a top-level call site. When the substring matches but no call is found, it emits a misleading warning on every build:

> [inertia-caseshift] Found createInertiaApp but could not locate the call site to transform. The plugin expects a top-level createInertiaApp({ ... }) call with an object literal argument. ...

In practice this fires against `@inertiajs/react/dist/index.js`, which declares and re-exports `createInertiaApp` without calling it (line 207 is the declaration, line 2108 is the re-export). The user's actual entry — `void createInertiaApp({ ... })` — is transformed correctly; the warning is about a transitive bundle they can't fix.

The premise of the warning is wrong: a file mentioning the symbol without calling it isn't misconfigured — it's just nothing to transform. Library bundles, helper modules, and re-export files all hit this path normally.

## Change

- `src/vite.ts`: remove the `console.warn`, keep the existing `return null`. Replace with a comment explaining why the path is a no-op.
- `tests/vite.test.ts`: add a regression test that declares and re-exports `createInertiaApp` without calling it, asserting both `null` return and no `console.warn` call.

## Repro for the original symptom

Bare Vite project with `@inertiajs/react` + `inertia-caseshift/vite`:

```ts
// vite.config.ts
import caseshift from "inertia-caseshift/vite"
import inertia from "@inertiajs/vite"
export default { plugins: [inertia(), caseshift({})] }

// entry.ts
import { createInertiaApp } from "@inertiajs/react"
void createInertiaApp({ pages: {/*...*/}, /*...*/ })
```

`vite build` prints the warning once — for `@inertiajs/react/dist/index.js`, not for the entry.

## Verification

- `pnpm test` — 173/173 pass (16 → 17 in `vite.test.ts`)
- `pnpm typecheck` — clean
- `pnpm lint` — clean