### PR TITLE
Scope transform hook so library bundles don't trigger the warn

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -15,39 +15,42 @@ export default function caseShift(options: CaseShiftPluginOptions = {}): Plugin 
   return {
     name: 'inertia-caseshift',
     enforce: 'post',
-    transform(code) {
-      if (!code.includes('createInertiaApp')) return null
-      if (code.includes('inertia-caseshift')) return null
+    transform: {
+      filter: {
+        id: { exclude: /\/node_modules\// },
+        code: { include: /createInertiaApp/, exclude: /inertia-caseshift/ },
+      },
+      handler(code) {
+        let ast: any
+        try {
+          ast = (this as any).parse(code)
+        } catch {
+          return null
+        }
 
-      let ast: any
-      try {
-        ast = (this as any).parse(code)
-      } catch {
+        const imports =
+          `import * as __cs from 'inertia-caseshift'\n` +
+          `import * as __csCore from '@inertiajs/core'\n`
+        const setup = `__cs.setupCaseShift(__csCore.http${optsArg})`
+
+        const renderPage = findRenderPage(ast)
+        if (renderPage) {
+          return transformSSR(code, imports, setup, renderPage, optsArg)
+        }
+
+        const inertiaCall = findInertiaCall(ast)
+        if (inertiaCall) {
+          return transformCSR(code, imports, setup, inertiaCall, appId, optsArg)
+        }
+
+        console.warn(
+          '[inertia-caseshift] Found createInertiaApp but could not locate the call site to transform. ' +
+          'The plugin expects a top-level createInertiaApp({ ... }) call with an object literal argument. ' +
+          'If you are using a non-standard setup, use setupCaseShift(http) and transformInitialPage() manually.',
+        )
+
         return null
-      }
-
-      const imports =
-        `import * as __cs from 'inertia-caseshift'\n` +
-        `import * as __csCore from '@inertiajs/core'\n`
-      const setup = `__cs.setupCaseShift(__csCore.http${optsArg})`
-
-      const renderPage = findRenderPage(ast)
-      if (renderPage) {
-        return transformSSR(code, imports, setup, renderPage, optsArg)
-      }
-
-      const inertiaCall = findInertiaCall(ast)
-      if (inertiaCall) {
-        return transformCSR(code, imports, setup, inertiaCall, appId, optsArg)
-      }
-
-      console.warn(
-        '[inertia-caseshift] Found createInertiaApp but could not locate the call site to transform. ' +
-        'The plugin expects a top-level createInertiaApp({ ... }) call with an object literal argument. ' +
-        'If you are using a non-standard setup, use setupCaseShift(http) and transformInitialPage() manually.',
-      )
-
-      return null
+      },
     },
   }
 }

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1,11 +1,20 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { parse } from 'acorn'
 import caseShift from '../src/vite'
 
-function transform(code: string, options?: { id?: string, rawKeys?: string[], skipKeys?: string[] }): string | null {
+function transform(
+  code: string,
+  options?: { id?: string, rawKeys?: string[], skipKeys?: string[] },
+  resourceId = 'app.tsx',
+): string | null {
   const plugin = caseShift(options)
+  const hook = (plugin as any).transform
+  const filter = hook.filter
+  if (filter?.id?.exclude?.test(resourceId)) return null
+  if (filter?.code?.include && !filter.code.include.test(code)) return null
+  if (filter?.code?.exclude?.test(code)) return null
   const ctx = { parse: (c: string) => parse(c, { ecmaVersion: 'latest', sourceType: 'module' }) }
-  const result = (plugin as any).transform.call(ctx, code, 'app.tsx')
+  const result = hook.handler.call(ctx, code)
   if (result === null) return null
   return typeof result === 'string' ? result : result.code
 }
@@ -24,6 +33,23 @@ describe('caseShift vite plugin', () => {
   it('skips files that already import inertia-caseshift', () => {
     const code = `import { setupCaseShift } from 'inertia-caseshift'\ncreateInertiaApp({ resolve: fn })`
     expect(transform(code)).toBeNull()
+  })
+
+  it('skips files under node_modules', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const code = `export { createInertiaApp } from '@inertiajs/react'`
+    expect(transform(code, undefined, '/project/node_modules/@inertiajs/react/dist/index.js')).toBeNull()
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('warns when user code references createInertiaApp without a call site', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const code = `export { createInertiaApp } from '@inertiajs/react'`
+    expect(transform(code)).toBeNull()
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toContain('could not locate the call site')
+    warn.mockRestore()
   })
 
   describe('CSR transform', () => {


### PR DESCRIPTION
Supersedes #3 — that one silenced the warn entirely, which loses signal for users who genuinely need to reach for `setupCaseShift` manually. Better fix: scope the hook so it doesn't inspect files where the warn can't apply.

## What changed

Restructures the `transform` hook to use the declarative `{ filter, handler }` shape and moves the three early-return guards into `filter`:

```js
transform: {
  filter: {
    id: { exclude: /\/node_modules\// },
    code: { include: /createInertiaApp/, exclude: /inertia-caseshift/ },
  },
  handler(code) { /* AST work only */ },
}
```

- `id.exclude` is the actual fix — `@inertiajs/react`'s bundle declares and re-exports `createInertiaApp` (line 207, line 2108), tripping the warn even though the user's entry is transformed correctly. No app has a legitimate reason to want the plugin to inspect `node_modules`, so the skip is a sensible default rather than a config knob.
- `code.include` / `code.exclude` are the substring guards from the original hook, lifted into the filter. Same booleans, no semantic change — just lets the plugin container short-circuit before the hook fires.

The warn stays put for the case it was written for: user-source code that mentions `createInertiaApp` without a recognizable call site.

## Verification

- `pnpm test` — 174/174 pass (16 → 18 in `vite.test.ts`)
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Spot-checked against a real Inertia + Vite 8 app (Rails + React entry); `vite build` is clean against the user entry and the bundle, no false positive.

Happy to split the refactor and the filter-restructure into separate commits if that's easier to review.